### PR TITLE
C9216: Inconsistent serial number due to extra spaces

### DIFF
--- a/powerapps-docs/customapi-web-api-tutorial.md
+++ b/powerapps-docs/customapi-web-api-tutorial.md
@@ -97,7 +97,7 @@ You should now be able to use AAD to authenticate your web application.
 ## Add the custom connector to PowerApps
 1. Modify your OpenAPI file to add the `securityDefintions` object and AAD authentication used for the Web App. The section of your OpenAPI file with the **host** property should look like this:
 
-    ```javascript
+```javascript
     // File header should be above here...
 
     "host": "<your-root-url>",
@@ -114,7 +114,7 @@ You should now be able to use AAD to authenticate your web application.
     },
 
     // The rest of the OpenAPI document follows...
-    ```
+```
 
 1. Browse to [PowerApps](https://web.powerapps.com), and add a custom connector as described in [Register and use custom connectors in PowerApps](register-custom-api.md).
 


### PR DESCRIPTION
Hello, @mgblythe,

Localization team has reported source content issue that causes localized version to have different format compared to en-us version. There are extra spaces that generate inconsistent serial number.

Please, help to check my proposed file change into the article and help to merge if you agree with fix. If not, please let me know either if you would like me to fix it in another way within this PR, if you prefer to fix it in another PR, or if I should close this PR as by-design. In case of using another PR, please let me know of your PR number, so we can confirm and close this PR.

Many thanks in advance.